### PR TITLE
Remove unnecessary `v`

### DIFF
--- a/lib/Release.js
+++ b/lib/Release.js
@@ -9,9 +9,7 @@ class Release {
     this.version = publication.version
     this.date = new Date(publication.date)
     this.modules = parseInt(publication.modules)
-
-    this.releaseLine = `${this.version.split('.')[0]}`
-
+    
     ;['npm', 'v8', 'uv', 'zlib', 'openssl'].forEach(k => {
       this[k] = publication[k]
     })

--- a/lib/Release.js
+++ b/lib/Release.js
@@ -10,7 +10,7 @@ class Release {
     this.date = new Date(publication.date)
     this.modules = parseInt(publication.modules)
 
-    this.releaseLine = `v${this.version.split('.')[0]}`
+    this.releaseLine = `${this.version.split('.')[0]}`
 
     ;['npm', 'v8', 'uv', 'zlib', 'openssl'].forEach(k => {
       this[k] = publication[k]


### PR DESCRIPTION
Removed unnecessary `v` that creates a different result than what was likely intended.

![image](https://user-images.githubusercontent.com/502396/46050460-4108ef00-c102-11e8-81b7-e4a24a88cb80.png)
