### PR TITLE
Enhance `amisafe` with suggested minimum Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,24 @@ if (releases.getLTS().length === 4 && // LTS release lines
 # Command Line
 <a name="cli"></a>
 
-## `amisafe`
+## Command Line Usage
 
-When the module is installed globally, running `amisafe` will tell you if you're using a version of Node.js with known vulnerabilities.
+The node-release-lines CLI options can be used globally or via npx.
+
+To use commands globally, with `amisafe` as an example:
+```
+npm install node-release-lines -g
+amisafe
+```
+
+To use via npx, with `amisafe` as an example:
+```
+npx node-release-lines amisafe
+```
+
+## Command: `amisafe`
+
+When the module is installed globally, running `amisafe` will tell you if you're using a version of Node.js with known vulnerabilities. If you _are_ running a version with vulnerabilities, `amisafe` will suggest the minimum safe version of Node.js.
 
 # API
 

--- a/bin/amisafe.js
+++ b/bin/amisafe.js
@@ -1,13 +1,20 @@
 #!/usr/bin/env node
 
-let safety
+var safety
 
-if(require('../').Release.load(process.version).isSafe === true) {
+var isSafe = require('../').Release.load(process.version).isSafe
+
+if(isSafe === true) {
   safety = "✅  Node.js " + process.version + " is safe!" 
   console.log(safety)
 }
 
-if(require('../').Release.load(process.version).isSafe === false) {
-  safety = "⚠️  Node.js " + process.version + " is not safe! Upgrade now." 
+var localReleaseLine = process.version.split('.')[0]
+var safeReleases = require('../').Releases.load(localReleaseLine).getSafe()
+var safeReleaseData = safeReleases[safeReleases.length - 1]
+var minimumSafeVersion = safeReleaseData.version
+
+if(isSafe === false) {
+  safety = "⚠️  Node.js " + process.version + " is not safe! You should upgrade now.\n\n👉  Minimum safe Node.js version in the " + localReleaseLine + " release line: " + minimumSafeVersion
   console.log(safety)
 }


### PR DESCRIPTION
Adds an enhancement to `amisafe` with a suggested minimum Node.js version when the _currently used version_ is insecure.