### PR TITLE
Add `nodetimeline` command

### DIFF
--- a/bin/nodetimeline.js
+++ b/bin/nodetimeline.js
@@ -52,13 +52,13 @@ releasesType.forEach(release => {
   console.log('')
   console.log('   ℹ️  Release Line Information')
   if(release.isCurrent) {
-    icon = 'Node.js '+ release.version + ' is under active development!'
+    console.log('      - Node.js '+ release.version + ' is under active development!')
   } else if (release.isActive && !release.isCurrent) {
-    icon = 'Node.js '+ release.version + ' is in the LTS phase of its lifecycle.' 
+    console.log('      - Node.js '+ release.version + ' is in the LTS phase of its lifecycle.')
   } else if (release.isMaintenance) {
-    icon = 'Node.js '+ release.version + ' is currently in Maintenance mode, and will only recieve security patches and bug fixes.'
+    console.log('      - Node.js '+ release.version + ' is currently in Maintenance mode, and will only recieve security patches and bug fixes.')
   } else if (release.isEOL) {
-    icon = 'Node.js '+ release.version + ' is in the End of Life (EOL) stage of its lifecycle, meaning it will recieve no further updates, fixes, or patches.'
+    console.log('      - Node.js '+ release.version + ' is in the End of Life (EOL) stage of its lifecycle, meaning it will recieve no further updates, fixes, or patches.')
   }
   console.log('')
   console.log('   📊  Release Line Metadata')

--- a/bin/nodetimeline.js
+++ b/bin/nodetimeline.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+var cli = require('commander')
+
+cli
+  .version('1.0.0', '-v, --version')
+  .usage('[options]')
+  .description('CLI tool to understand Node.js release lines lifespans.')
+  .option('-c, --current', 'Returns all "Current" versions of Node.js.')
+  .option('-l, --lts', 'Returns all presently supported "LTS" versions of Node.js – regardless of whether or not they are presently active "LTS".')
+  .option('-a, --active', 'Returns all active "LTS" Node.js release lines.')
+  .option('-m, --maintenance', 'Returns all presently supported "Maintenance" versions of Node.js.')
+  .option('-s, --supported', 'Returns all presently supported Node.js version')
+  .parse(process.argv)
+
+var api = require('../')
+var releases = api.ReleaseLines.load()
+let v = process.version.split('.')
+
+var releasesType = [releases.get(v[0])]
+
+if(cli.current) {
+  releasesType = releases.getCurrent()
+} else if (cli.lts) {
+  releasesType = releases.getLTS()
+} else if (cli.active) {
+  releasesType = releases.getActive()
+} else if (cli.maintenance) {
+  releasesType = releases.getMaintenance()
+} else if (cli.supported) {
+  releasesType = releases.getSupported()
+} else if (cli.modern) {
+  releasesType = releases.getModern()
+}
+releasesType.forEach(release => {
+  var icon
+  if(release.isCurrent) {
+    icon = '✅'
+  } else if (release.isActive && !release.isCurrent) {
+    icon = '🆗'
+  } else if (release.isMaintenance) {
+    icon = '⚠️'
+  } else if (release.isEOL) {
+    icon = '☠️'
+  }
+
+  var stats = release.getStats()
+
+  console.log(icon + '  Node.js ' + release.version + ' Timeline')
+  console.log('      - Node.js ' + release.version + ' will be EOL in ' + stats.days.until.eol + ' days.')
+  console.log('      - Node.js ' + release.version + ' is ' + stats.percent.total + '% through its total lifespan.')
+  console.log('')
+  console.log('   ℹ️  Release Line Information')
+  if(release.isCurrent) {
+    icon = 'Node.js '+ release.version + ' is under active development!'
+  } else if (release.isActive && !release.isCurrent) {
+    icon = 'Node.js '+ release.version + ' is in the LTS phase of its lifecycle.' 
+  } else if (release.isMaintenance) {
+    icon = 'Node.js '+ release.version + ' is currently in Maintenance mode, and will only recieve security patches and bug fixes.'
+  } else if (release.isEOL) {
+    icon = 'Node.js '+ release.version + ' is in the End of Life (EOL) stage of its lifecycle, meaning it will recieve no further updates, fixes, or patches.'
+  }
+  console.log('')
+  console.log('   📊  Release Line Metadata')
+  console.log('      - There are a total of ' + release.releases.length + ' releases in the Node.js ' + release.version + 'release line.')
+  console.log('      - There are currently ' + release.releases.getSafe().length + ' releases in the Node.js ' + release.version + 'that have zero known vulnerabilities.')
+  console.log('      - The latest release in the'  + release.version +  ' release line is ' + release.releases[0].version)
+  console.log('')
+})

--- a/bin/nodetimeline.js
+++ b/bin/nodetimeline.js
@@ -62,8 +62,8 @@ releasesType.forEach(release => {
   }
   console.log('')
   console.log('   📊  Release Line Metadata')
-  console.log('      - There are a total of ' + release.releases.length + ' releases in the Node.js ' + release.version + 'release line.')
-  console.log('      - There are currently ' + release.releases.getSafe().length + ' releases in the Node.js ' + release.version + 'that have zero known vulnerabilities.')
+  console.log('      - There are a total of ' + release.releases.length + ' releases in the Node.js ' + release.version + ' release line.')
+  console.log('      - There are currently ' + release.releases.getSafe().length + ' releases in the Node.js ' + release.version + ' that have zero known vulnerabilities.')
   console.log('      - The latest release in the'  + release.version +  ' release line is ' + release.releases[0].version)
   console.log('')
 })

--- a/bin/nodetimeline.js
+++ b/bin/nodetimeline.js
@@ -19,7 +19,7 @@ let v = process.version.split('.')
 
 var releasesType = [releases.get(v[0])]
 
-if(cli.current) {
+if (cli.current) {
   releasesType = releases.getCurrent()
 } else if (cli.lts) {
   releasesType = releases.getLTS()
@@ -34,7 +34,7 @@ if(cli.current) {
 }
 releasesType.forEach(release => {
   var icon
-  if(release.isCurrent) {
+  if (release.isCurrent) {
     icon = '✅'
   } else if (release.isActive) {
     icon = '🆗'
@@ -51,19 +51,19 @@ releasesType.forEach(release => {
   console.log('      - Node.js ' + release.version + ' is ' + stats.percent.total + '% through its total lifespan.')
   console.log('')
   console.log('   ℹ️  Release Line Information')
-  if(release.isCurrent) {
-    console.log('      - Node.js '+ release.version + ' is under active development!')
+  if (release.isCurrent) {
+    console.log('      - Node.js ' + release.version + ' is under active development!')
   } else if (release.isActive) {
-    console.log('      - Node.js '+ release.version + ' is in the LTS phase of its lifecycle.')
+    console.log('      - Node.js ' + release.version + ' is in the LTS phase of its lifecycle.')
   } else if (release.isMaintenance) {
-    console.log('      - Node.js '+ release.version + ' is currently in Maintenance mode, and will only recieve security patches and bug fixes.')
+    console.log('      - Node.js ' + release.version + ' is currently in Maintenance mode, and will only recieve security patches and bug fixes.')
   } else if (release.isEOL) {
-    console.log('      - Node.js '+ release.version + ' is in the End of Life (EOL) stage of its lifecycle, meaning it will recieve no further updates, fixes, or patches.')
+    console.log('      - Node.js ' + release.version + ' is in the End of Life (EOL) stage of its lifecycle, meaning it will recieve no further updates, fixes, or patches.')
   }
   console.log('')
   console.log('   📊  Release Line Metadata')
   console.log('      - There are a total of ' + release.releases.length + ' releases in the Node.js ' + release.version + ' release line.')
   console.log('      - There are currently ' + release.releases.getSafe().length + ' releases in the Node.js ' + release.version + ' that have zero known vulnerabilities.')
-  console.log('      - The latest release in the '  + release.version +  ' release line is ' + release.releases[0].version)
+  console.log('      - The latest release in the ' + release.version + ' release line is ' + release.releases[0].version)
   console.log('')
 })

--- a/bin/nodetimeline.js
+++ b/bin/nodetimeline.js
@@ -36,7 +36,7 @@ releasesType.forEach(release => {
   var icon
   if(release.isCurrent) {
     icon = '✅'
-  } else if (release.isActive && !release.isCurrent) {
+  } else if (release.isActive) {
     icon = '🆗'
   } else if (release.isMaintenance) {
     icon = '⚠️'
@@ -53,7 +53,7 @@ releasesType.forEach(release => {
   console.log('   ℹ️  Release Line Information')
   if(release.isCurrent) {
     console.log('      - Node.js '+ release.version + ' is under active development!')
-  } else if (release.isActive && !release.isCurrent) {
+  } else if (release.isActive) {
     console.log('      - Node.js '+ release.version + ' is in the LTS phase of its lifecycle.')
   } else if (release.isMaintenance) {
     console.log('      - Node.js '+ release.version + ' is currently in Maintenance mode, and will only recieve security patches and bug fixes.')
@@ -64,6 +64,6 @@ releasesType.forEach(release => {
   console.log('   📊  Release Line Metadata')
   console.log('      - There are a total of ' + release.releases.length + ' releases in the Node.js ' + release.version + ' release line.')
   console.log('      - There are currently ' + release.releases.getSafe().length + ' releases in the Node.js ' + release.version + ' that have zero known vulnerabilities.')
-  console.log('      - The latest release in the'  + release.version +  ' release line is ' + release.releases[0].version)
+  console.log('      - The latest release in the '  + release.version +  ' release line is ' + release.releases[0].version)
   console.log('')
 })

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "bin": {
     "amisafe": "./bin/isnodesafe.js",
-    "isnodesafe": "./bin/isnodesafe.js"
+    "isnodesafe": "./bin/isnodesafe.js",
+    "nodetimeline": "./bin/nodetimeline.js"
   },
   "scripts": {
     "test": "mocha",


### PR DESCRIPTION
This PR is a first pass at a `nodetimeline` command. Before writing docs I'd like to get feedback on the API 🙌

Two notes:

I initially had an `--eol` flag but it did not play well with line 67, which checks what the latest version is – it seems `getEOL()` doesn't return identical data to the others (which is fine!).

I could also add checking a specific version, but figured I'd get this up since it's starting to get a bit late and I've been working on this for a few hours now.